### PR TITLE
LOTD compatibility patches masterlist update (#221)

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -3988,24 +3988,229 @@ plugins:
     msg:
       - <<: *hasPatchIncluded
         subs:
+          - '[Advanced Adversary Encounters - Ultimate SSE](https://www.nexusmods.com/skyrimspecialedition/mods/6843/)'
+          - '[Legacy of the Dragonborn Patches SE](https://www.nexusmods.com/skyrimspecialedition/mods/11802)'
+        condition: 'active("AAE Ultimate Edition.esp") and not active("DBM_AAE_Patch.esp")'
+      - <<: *hasPatchIncluded
+        subs:
+          - '[Amulets of Skyrim SSE](https://www.nexusmods.com/skyrimspecialedition/mods/487/)'
+          - '[Legacy of the Dragonborn Patches SE](https://www.nexusmods.com/skyrimspecialedition/mods/11802)'
+        condition: 'active("SL01AmuletsSkyrim.esp") and not active("DBM_AmuletsOfSkyrim_Patch.esp")'
+      - <<: *hasPatchIncluded
+        subs:
+          - '[Artifacts - The Ice Blade of the Monarch](https://www.nexusmods.com/skyrimspecialedition/mods/13972/)'
+          - '[Legacy of the Dragonborn Patches SE](https://www.nexusmods.com/skyrimspecialedition/mods/11802)'
+        condition: 'active("IceBladeOfTheMonarch.esp") and not active("DBM_IceBladeMonarch_Patch.esp")'
+      - <<: *hasPatchIncluded
+        subs:
+          - '[Artifacts - The Tournament of the Ten Bloods](https://www.nexusmods.com/skyrimspecialedition/mods/15264/)'
+          - '[Legacy of the Dragonborn Patches SE](https://www.nexusmods.com/skyrimspecialedition/mods/11802)'
+        condition: 'active("ArtifactsOfBoethiah.esp") and not active("DBM_ArtifactsOfBoethiah_Patch.esp")'
+      - <<: *hasPatchIncluded
+        subs:
+          - '[Artificer - Artifacts of Skyrim](https://www.nexusmods.com/skyrimspecialedition/mods/6674/)'
+          - '[Legacy of the Dragonborn Patches SE](https://www.nexusmods.com/skyrimspecialedition/mods/11802)'
+        condition: 'active("Artificer - Artifacts of Skyrim.esp") and not active("DBM_Artificer_Patch.esp")'
+      - <<: *hasPatchIncluded
+        subs:
+          - '[Audio Overhaul Skyrim SE](https://www.nexusmods.com/skyrimspecialedition/mods/12466/)'
+          - '[Legacy of the Dragonborn Patches SE](https://www.nexusmods.com/skyrimspecialedition/mods/11802)'
+        condition: 'active("Audio Overhaul Skyrim.esp") and not active("DBM_AOS_Patch.esp")'
+      - <<: *hasPatchIncluded
+        subs:
+          - '[Better Skill and Quest Books Names SE](https://www.nexusmods.com/skyrimspecialedition/mods/5260/)'
+          - '[Legacy of the Dragonborn Patches SE](https://www.nexusmods.com/skyrimspecialedition/mods/11802)'
+        condition: 'active("Better Skill and Quest Books Names SE.esp") and not active("BCS_BSQBN_Patch.esp")'
+      - <<: *hasPatchIncluded
+        subs:
+          - '[Beyond Reach](https://www.nexusmods.com/skyrimspecialedition/mods/3008/)'
+          - '[Legacy of the Dragonborn Patches SE](https://www.nexusmods.com/skyrimspecialedition/mods/11802)'
+        condition: 'active("arnima.esm") and not active("DBM_BeyondReach_Patch.esp")'
+      - <<: *hasPatchIncluded
+        subs:
+          - '[Beyond Skyrim - Bruma SE](https://www.nexusmods.com/skyrimspecialedition/mods/10917/)'
+          - '[Legacy of the Dragonborn Patches SE](https://www.nexusmods.com/skyrimspecialedition/mods/11802)'
+        condition: 'active("BSHeartland.esm") and not active("DBM_Bruma_Patch.esp")'
+      - <<: *hasPatchIncluded
+        subs:
+          - '[BUVARP SE - Barely Used Vanilla Actors Recycle Project For SE](https://www.nexusmods.com/skyrimspecialedition/mods/13562/)'
+          - '[Legacy of the Dragonborn Patches SE](https://www.nexusmods.com/skyrimspecialedition/mods/11802)'
+        condition: 'active("BUVARP.esp") and not active("DBM_BUVARP_Patch.esp")'
+      - <<: *hasPatchIncluded
+        subs:
+          - '[Cloaks of Skyrim](https://www.nexusmods.com/skyrimspecialedition/mods/6369/)'
+          - '[Legacy of the Dragonborn Patches SE](https://www.nexusmods.com/skyrimspecialedition/mods/11802)'
+        condition: 'active("Cloaks.esp") and not active("DBM_Cloaks_Patch.esp")'
+      - <<: *hasPatchIncluded
+        subs:
           - '[Cutting Room Floor](https://www.nexusmods.com/skyrimspecialedition/mods/276/)'
-          - '[Legacy of the Dragonborn SSE](https://www.nexusmods.com/skyrimspecialedition/mods/11802)'
+          - '[Legacy of the Dragonborn Patches SE](https://www.nexusmods.com/skyrimspecialedition/mods/11802)'
         condition: 'active("Cutting Room Floor.esp") and not active("DBM_CRF_Patch.esp")'
       - <<: *hasPatchIncluded
         subs:
+          - '[Daedric Cloaks](https://www.nexusmods.com/skyrimspecialedition/mods/9530/)'
+          - '[Legacy of the Dragonborn Patches SE](https://www.nexusmods.com/skyrimspecialedition/mods/11802)'
+        condition: 'active("DaedricCloaks.esp") and not active("DBM_DaedricCloaks_Patch.esp")'
+      - <<: *hasPatchIncluded
+        subs:
+          - '[Daedric Realms - Volume I The Hunting Grounds](https://www.nexusmods.com/skyrimspecialedition/mods/3140/)'
+          - '[Legacy of the Dragonborn Patches SE](https://www.nexusmods.com/skyrimspecialedition/mods/11802)'
+        condition: 'active("StagPrinceBow.esp") and not active("DBM_StagPrinceBow_Patch.esp")'
+      - <<: *hasPatchIncluded
+        subs:
+          - '[Dark Brotherhood for Good Guys](https://www.nexusmods.com/skyrimspecialedition/mods/519/)'
+          - '[Legacy of the Dragonborn Patches SE](https://www.nexusmods.com/skyrimspecialedition/mods/11802)'
+        condition: 'active("goodbrother.esp") and not active("DBM_GoodBrother_Patch.esp")'
+      - <<: *hasPatchIncluded
+        subs:
+          - '[Dawnguard and Clan Volkihar Epilogues](https://www.nexusmods.com/skyrimspecialedition/mods/12098/)'
+          - '[Legacy of the Dragonborn Patches SE](https://www.nexusmods.com/skyrimspecialedition/mods/11802)'
+        condition: 'active("Dawngaurd&VolkiharArtifactsQuests.esp") and not active("DBM_DGE_Patch.esp")'
+      - <<: *hasPatchIncluded
+        subs:
+          - '[Legendary Skyrim Crossbows SSE](https://www.nexusmods.com/skyrimspecialedition/mods/8273/)'
+          - '[Legacy of the Dragonborn Patches SE](https://www.nexusmods.com/skyrimspecialedition/mods/11802)'
+        condition: 'active("Dawngaurd&VolkiharArtifactsQuests.esp.esp") and active("Legendary Skyrim Crossbows.esp") and not active("DBM_DGE_Crossbow_Patch.esp")'
+      - <<: *hasPatchIncluded
+        subs:
+          - '[Dynamic Dungeon Loot](https://www.nexusmods.com/skyrimspecialedition/mods/10308/)'
+          - '[Legacy of the Dragonborn Patches SE](https://www.nexusmods.com/skyrimspecialedition/mods/11802)'
+        condition: 'active("DynamicDungeonLoot.esp") and not active("DBM_DDL_Patch.esp")'
+      - <<: *hasPatchIncluded
+        subs:
+          - '[Elemental Dragons Special Edition](https://www.nexusmods.com/skyrimspecialedition/mods/8394/)'
+          - '[Legacy of the Dragonborn Patches SE](https://www.nexusmods.com/skyrimspecialedition/mods/11802)'
+        condition: 'active("Elemental_Dragons.esp") and not active("DBM_ElementalDragons_Patch.esp")'
+      - <<: *hasPatchIncluded
+        subs:
+          - '[Even Better Quest Objectives](https://www.nexusmods.com/skyrimspecialedition/mods/159/)'
+          - '[Legacy of the Dragonborn Patches SE](https://www.nexusmods.com/skyrimspecialedition/mods/11802)'
+        condition: 'active("BetterQuestObjectives.esp") and not active("BetterQuestObjectives - BCS Patch.esp")'
+      - <<: *hasPatchIncluded
+        subs:
+          - '[Heavy Armory - New Weapons](https://www.nexusmods.com/skyrimspecialedition/mods/6308/)'
+          - '[Legacy of the Dragonborn Patches SE](https://www.nexusmods.com/skyrimspecialedition/mods/11802)'
+        condition: 'active("Prvtl_HeavyArmory.esp") and not active("DBM_HA_Patch.esp")'
+      - <<: *hasPatchIncluded
+        subs:
           - '[Helgen Reborn](https://www.nexusmods.com/skyrimspecialedition/mods/5673/)'
-          - '[Legacy of the Dragonborn SSE](https://www.nexusmods.com/skyrimspecialedition/mods/11802)'
+          - '[Legacy of the Dragonborn Patches SE](https://www.nexusmods.com/skyrimspecialedition/mods/11802)'
         condition: 'active("Helgen Reborn.esp") and not active("DBM_HelgenReborn_Patch.esp")'
       - <<: *hasPatchIncluded
         subs:
-          - '[Skyrim Underground](https://www.nexusmods.com/skyrimspecialedition/mods/131/)'
-          - '[Legacy of the Dragonborn SSE](https://www.nexusmods.com/skyrimspecialedition/mods/11802)'
-        condition: 'active("AKSkyrimUnderground.esp") and not active("DBM_SkyrimUnderground_Patch.esp")'
+          - '[Holds the City Overhaul](https://www.nexusmods.com/skyrimspecialedition/mods/10609/)'
+          - '[Legacy of the Dragonborn Patches SE](https://www.nexusmods.com/skyrimspecialedition/mods/11802)'
+        condition: 'active("Holds.esp") and not active("DBM_Holds_Patch.esp")'
+      - <<: *hasPatchIncluded
+        subs:
+          - '[iNeed - Food Water and Sleep](https://www.nexusmods.com/skyrimspecialedition/mods/645/)'
+          - '[Legacy of the Dragonborn Patches SE](https://www.nexusmods.com/skyrimspecialedition/mods/11802)'
+        condition: 'active("iNeed - Extended.esp") and not active("DBM_iNeed_Patch.esp")'
+      - <<: *hasPatchIncluded
+        subs:
+          - '[Immersive Armors](https://www.nexusmods.com/skyrimspecialedition/mods/3479/)'
+          - '[Legacy of the Dragonborn Patches SE](https://www.nexusmods.com/skyrimspecialedition/mods/11802)'
+        condition: 'active("Hothtrooper44_ArmorCompilation.esp") and not active("DBM_IA_Patch.esp")'
+      - <<: *hasPatchIncluded
+        subs:
+          - '[Immersive Sounds - Compendium](https://www.nexusmods.com/skyrimspecialedition/mods/523/)'
+          - '[Legacy of the Dragonborn Patches SE](https://www.nexusmods.com/skyrimspecialedition/mods/11802)'
+        condition: 'active("Immersive Sounds - Compendium.esp") and not active("DBM_ISC_Patch.esp")'
+      - <<: *hasPatchIncluded
+        subs:
+          - '[Immersive Weapons](https://www.nexusmods.com/skyrimspecialedition/mods/16788/)'
+          - '[Legacy of the Dragonborn Patches SE](https://www.nexusmods.com/skyrimspecialedition/mods/11802)'
+        condition: 'active("Immersive Weapons.esp") and not active("DBM_IW_Patch.esp")'
+      - <<: *hasPatchIncluded
+        subs:
+          - '[Legendary Skyrim Crossbows SSE](https://www.nexusmods.com/skyrimspecialedition/mods/8273/)'
+          - '[Legacy of the Dragonborn Patches SE](https://www.nexusmods.com/skyrimspecialedition/mods/11802)'
+        condition: 'active("Legendary Skyrim Crossbows.esp") and not active("DBM_KelCrossbow_Patch.esp")'
+      - <<: *hasPatchIncluded
+        subs:
+          - '[Moon and Star](https://www.nexusmods.com/skyrimspecialedition/mods/4301/)'
+          - '[Legacy of the Dragonborn Patches SE](https://www.nexusmods.com/skyrimspecialedition/mods/11802)'
+        condition: 'active("MoonAndStar_MAS.esp") and not active("DBM_MAS_Patch.esp")'
+      - <<: *hasPatchIncluded
+        subs:
+          - '[MorrowLoot Ultimate](https://www.nexusmods.com/skyrimspecialedition/mods/3058/)'
+          - '[Legacy of the Dragonborn Patches SE](https://www.nexusmods.com/skyrimspecialedition/mods/11802)'
+        condition: 'active("MLU.esp") and not active("DBM_MLU_Patch.esp")'
+      - <<: *hasPatchIncluded
+        subs:
+          - '[Oblivion Artifact Pack SE](https://www.nexusmods.com/skyrimspecialedition/mods/10644/)'
+          - '[Legacy of the Dragonborn Patches SE](https://www.nexusmods.com/skyrimspecialedition/mods/11802)'
+        condition: 'active("WZOblivionArtifacts.esp") and not active("DBM_OblivionArtifacts_Patch.esp")'
       - <<: *hasPatchIncluded
         subs:
           - '[Open Cities Skyrim](https://www.nexusmods.com/skyrimspecialedition/mods/281/)'
-          - '[Legacy of the Dragonborn SSE](https://www.nexusmods.com/skyrimspecialedition/mods/11802)'
+          - '[Legacy of the Dragonborn Patches SE](https://www.nexusmods.com/skyrimspecialedition/mods/11802)'
         condition: 'active("Open Cities Skyrim.esp") and not active("DBM_OpenCities_Patch.esp")'
+      - <<: *hasPatchIncluded
+        subs:
+          - '[Path of the Revenant](https://www.nexusmods.com/skyrimspecialedition/mods/2352/)'
+          - '[Legacy of the Dragonborn Patches SE](https://www.nexusmods.com/skyrimspecialedition/mods/11802)'
+        condition: 'active("bloodworm.esp") and not active("DBM_Bloodworm_Patch.esp")'
+      - <<: *hasPatchIncluded
+        subs:
+          - '[Royal Armory - New Artifacts](https://www.nexusmods.com/skyrimspecialedition/mods/6994/)'
+          - '[Legacy of the Dragonborn Patches SE](https://www.nexusmods.com/skyrimspecialedition/mods/11802)'
+        condition: 'active("PrvtlRoyalArmory.esp") and not active("DBM_RoyalArmory_Patch.esp")'
+      - <<: *hasPatchIncluded
+        subs:
+          - '[Ruins Edge](https://www.nexusmods.com/skyrimspecialedition/mods/12792/)'
+          - '[Legacy of the Dragonborn Patches SE](https://www.nexusmods.com/skyrimspecialedition/mods/11802)'
+        condition: 'active("RuinsEdge.esp") and not active("DBM_RuinsEdge_Patch.esp")'
+      - <<: *hasPatchIncluded
+        subs:
+          - '[Skyrim Immersive Creatures Special Edition](https://www.nexusmods.com/skyrimspecialedition/mods/12680/)'
+          - '[Legacy of the Dragonborn Patches SE](https://www.nexusmods.com/skyrimspecialedition/mods/11802)'
+        condition: 'active("Skyrim Immersive Creatures Special Edition.esp") and not active("DBM_ImmersiveCreatures_Patch.esp")'
+      - <<: *hasPatchIncluded
+        subs:
+          - '[Skyrim Underground](https://www.nexusmods.com/skyrimspecialedition/mods/131/)'
+          - '[Legacy of the Dragonborn Patches SE](https://www.nexusmods.com/skyrimspecialedition/mods/11802)'
+        condition: 'active("AKSkyrimUnderground.esp") and not active("DBM_SkyrimUnderground_Patch.esp")'
+      - <<: *hasPatchIncluded
+        subs:
+          - '[Solitude Skyway](https://www.nexusmods.com/skyrimspecialedition/mods/8250/)'
+          - '[Legacy of the Dragonborn Patches SE](https://www.nexusmods.com/skyrimspecialedition/mods/11802)'
+        condition: 'active("Solitude Skyway SE.esp") and not active("DBM_Skyway_Patch.esp")'
+      - <<: *hasPatchIncluded
+        subs:
+          - '[The Choice is Yours](https://www.nexusmods.com/skyrimspecialedition/mods/3850/)'
+          - '[Legacy of the Dragonborn Patches SE](https://www.nexusmods.com/skyrimspecialedition/mods/11802)'
+        condition: 'active("TheChoiceIsYours.esp") and not active("BCS_TCIY_Patch.esp")'
+      - <<: *hasPatchIncluded
+        subs:
+          - '[The Staff of Sheogorath](https://www.nexusmods.com/skyrimspecialedition/mods/14468/)'
+          - '[Legacy of the Dragonborn Patches SE](https://www.nexusmods.com/skyrimspecialedition/mods/11802)'
+        condition: 'active("StaffOfSheogorath.esp") and not active("DBM_StaffofSheogorath_Patch.esp")'
+      - <<: *hasPatchIncluded
+        subs:
+          - '[Ultimate Deadly Encounters](https://www.nexusmods.com/skyrimspecialedition/mods/3093/)'
+          - '[Legacy of the Dragonborn Patches SE](https://www.nexusmods.com/skyrimspecialedition/mods/11802)'
+        condition: 'active("SOTFull.esp") and not active("DBM_SoT_Patch.esp")'
+      - <<: *hasPatchIncluded
+        subs:
+          - '[Undeath Remastered](https://www.nexusmods.com/skyrimspecialedition/mods/6180/)'
+          - '[Legacy of the Dragonborn Patches SE](https://www.nexusmods.com/skyrimspecialedition/mods/11802)'
+        condition: 'active("Undeath.esp") and not active("DBM_Undeath_Patch.esp")'
+      - <<: *hasPatchIncluded
+        subs:
+          - '[Unique Loot - An Immersive Looting Experience](https://www.nexusmods.com/skyrimspecialedition/mods/734/)'
+          - '[Legacy of the Dragonborn Patches SE](https://www.nexusmods.com/skyrimspecialedition/mods/11802)'
+        condition: 'active("mrbs-uniqueloot-se.esp") and not active("DBM_UniqueLoot_Patch.esp")'
+      - <<: *hasPatchIncluded
+        subs:
+          - '[VIGILANT SE](https://www.nexusmods.com/skyrimspecialedition/mods/11849/)'
+          - '[Legacy of the Dragonborn Patches SE](https://www.nexusmods.com/skyrimspecialedition/mods/11802)'
+        condition: 'active("Vigilant.esp") and not active("DBM_Vigilant_Patch.esp")'
+      - <<: *hasPatchIncluded
+        subs:
+          - '[YASH - Yet Another Skyrim Hardcore Mod](https://www.nexusmods.com/skyrimspecialedition/mods/2430/)'
+          - '[Legacy of the Dragonborn Patches SE](https://www.nexusmods.com/skyrimspecialedition/mods/11802)'
+        condition: 'active("YASH2.esp") and not active("DBM_YASH_Patch.esp")'
     tag:
       - C.Location
       - Delev


### PR DESCRIPTION
* Added Better Skill and Quest Books Names SE compatibility patch to LOTD

* Even Better Quest Objectives LOTD compat patch

* Holds the city overhaul LOTD SE compat patch

* TCIY - LOTD Compatibility Patch

* Advanced Adversary Encounters - LOTD Compatibility patch

* Amulets of Skyrim - LOTD compatibility patch

* AOS - LOTD compat patch

* Artificer - LOTD compatibility patch

* Beyond Reach - LOTD compatibility patch

* Path of the Revenant - LOTD compat patch

* Beyond Skyrim - Bruma LOTD compat patch

* BUVARP LOTD compat patch

* Cloaks LOTD compatibility patch

* Daedric Cloaks LOTD compat patch

* DDL LOTD compat patch

* DG&Volkihar epilogue LOTD compat patch

* Corrected Dawnguard epilogue LOTD compatibility patch

* YASH - LOTD compat patch and Elemental Dragons - LOTD compatibility patch

* Vigilant LOTD compat patch

* Unique Loot LOTD compat patch

* Undeath LOTD compat patch

* ineed LOTD compat patch

* Immersive Sounds LOTD compat patch

* Immersive Weapons LOTD compat patch

* Immersive Creatures LOTD compat patch

* Immersive Armors LOTD compat patch

* Staff of Sheo LOTD compat patch

* Solitude Skyway LOTD compat patch

* Royal Armory LOTD compat patch

* DB for Good guys LOTD compat patch

* SoT LOTD compat patch

* Oblivion Artifacts LOTD compat patch

* MLU LOTD compat patch

* MAS LOTD compat patch

* LegendSkyCrossbow LOTD compat patch

* Legendary Skyrim Crossbows - Volkihar Epilogue - LOTD compat patch

* IceBladeMonarch LOTD compat patch

* Heavy Armory - LOTD Compat patch

* RuinsEdge, StagPrinceBow, ArtifactsOfBoethiah LOTD Compat Patch

* subs consistency fix
Changed link name to reflect the actual file title.
Legacy of the Dragonborn SSE -> Legacy of the Dragonborn Patches